### PR TITLE
Fix module loading in Electron 4

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,6 @@
             "includes/FindGitRepos.h",
             "includes/Queue.h"
         ],
-        "win_delay_load_hook": "false",
         "include_dirs": [
             "<!(node -e \"require('nan')\")",
             "includes"


### PR DESCRIPTION
See: https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook